### PR TITLE
feat(python): add Python development environment support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,9 @@ WWW_DIR=../../www
 # Nginx logs directory
 NGINX_LOG_DIR=./log/nginx
 
+# Python logs directory
+PYTHON_LOG_DIR=./log/python
+
 
 # ==============================================================================
 # Nginx
@@ -128,3 +131,14 @@ MYSQL80_EXPOSING_PORT=11801
 
 # Slave port
 MYSQL80_SLAVE_EXPOSING_PORT=11802
+
+# ==============================================================================
+# Python
+# ==============================================================================
+# Python versions available: 3.10-web, 3.11-web, 3.12-web, latest-web
+PYTHON_DEFAULT_VERSION=3.11
+
+# Python ports for direct access (optional, if needed)
+# PYTHON310_EXPOSING_PORT=11950
+# PYTHON311_EXPOSING_PORT=11951
+# PYTHON312_EXPOSING_PORT=11952

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,371 @@
+version: "3.8"
+
+# ==============================================================================
+# Networks
+# ==============================================================================
+networks:
+    {{DEV_NAMESPACE}}:
+        name: {{DEV_NAMESPACE}}_default
+        driver: bridge
+
+# ==============================================================================
+# Volumes
+# ==============================================================================
+volumes:
+    mariadb-data:
+        driver: local
+        name: {{DEV_NAMESPACE}}_mariadb_data
+    es-data:
+        driver: local
+        name: {{DEV_NAMESPACE}}_elasticsearch_data
+
+# ==============================================================================
+# Services
+# ==============================================================================
+services:
+    # ==========================================================================
+    # Nginx - Web Server
+    # ==========================================================================
+    nginx_main:
+        image: manhphucofficial/nginx:${NGINX_VERSION}-alpine-custom
+        container_name: {{DEV_NAMESPACE}}_nginx_main
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared:ro"
+            - "./etc/nginx:/etc/nginx/conf.d:ro"
+            - "./etc/ssl:/etc/ssl:ro"
+            - "${WWW_DIR}:/var/www/html"
+            - "${NGINX_LOG_DIR}:/var/log/nginx"
+        ports:
+            - "${NGINX_HTTP_EXPOSING_PORT}:80"
+            - "${NGINX_HTTPS_EXPOSING_PORT}:443"
+        environment:
+            - NGINX_HOST=${NGINX_HOST}
+        networks:
+            - {{DEV_NAMESPACE}}
+        depends_on:
+            - php72_fpm
+            - php82_web
+            - php_latest_fpm
+
+    # ==========================================================================
+    # PHP 7.2 - FPM
+    # ==========================================================================
+    php72_fpm:
+        image: manhphucofficial/php:7.2-fpm
+        container_name: {{DEV_NAMESPACE}}_php72_fpm
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "./etc/php72/php-custom.ini:/etc/php/7.2/fpm/conf.d/php-custom.ini:ro"
+        environment:
+            - PHP_UPLOAD_MAX_FILESIZE=256M
+            - PHP_POST_MAX_SIZE=256M
+            - PHP_MEMORY_LIMIT=256M
+            - PHP_MAX_EXECUTION_TIME=300
+            - PHP_MAX_INPUT_TIME=300
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # PHP 8.2 - Web (FPM + Nginx)
+    # ==========================================================================
+    php82_web:
+        image: manhphucofficial/php82_web
+        container_name: {{DEV_NAMESPACE}}_php82_web
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "./etc/php82/php-custom.ini:/etc/php/8.2/fpm/conf.d/php-custom.ini:ro"
+            - "./etc/ssl/dev-srv.org.key:/etc/nginx/certs/dev-srv.org.key:ro"
+            - "./etc/ssl/dev-srv.org.bundle.crt:/etc/nginx/certs/dev-srv.org.crt:ro"
+        environment:
+            - PHP_UPLOAD_MAX_FILESIZE=256M
+            - PHP_POST_MAX_SIZE=256M
+            - PHP_MEMORY_LIMIT=256M
+            - PHP_MAX_EXECUTION_TIME=300
+            - PHP_MAX_INPUT_TIME=300
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # PHP Latest - FPM
+    # ==========================================================================
+    php_latest_fpm:
+        image: manhphucofficial/php:latest-fpm
+        container_name: {{DEV_NAMESPACE}}_php_latest_fpm
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "./etc/php-latest/php-custom.ini:/etc/php/7.4/fpm/conf.d/php-custom.ini:ro"
+            - "./etc/ssl/dev-srv.org.key:/etc/nginx/certs/dev-srv.org.key:ro"
+            - "./etc/ssl/dev-srv.org.bundle.crt:/etc/nginx/certs/dev-srv.org.crt:ro"
+        environment:
+            - PHP_UPLOAD_MAX_FILESIZE=256M
+            - PHP_POST_MAX_SIZE=256M
+            - PHP_MEMORY_LIMIT=256M
+            - PHP_MAX_EXECUTION_TIME=300
+            - PHP_MAX_INPUT_TIME=300
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # Python 3.10 - Web
+    # ==========================================================================
+    python310_web:
+        image: manhphucofficial/python:3.10-web
+        container_name: {{DEV_NAMESPACE}}_python310_web
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - PIP_NO_CACHE_DIR=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # Python 3.11 - Web
+    # ==========================================================================
+    python311_web:
+        image: manhphucofficial/python:3.11-web
+        container_name: {{DEV_NAMESPACE}}_python311_web
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - PIP_NO_CACHE_DIR=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # Python 3.12 - Web
+    # ==========================================================================
+    python312_web:
+        image: manhphucofficial/python:3.12-web
+        container_name: {{DEV_NAMESPACE}}_python312_web
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - PIP_NO_CACHE_DIR=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # Python Latest - Web
+    # ==========================================================================
+    python_latest_web:
+        image: manhphucofficial/python:latest-web
+        container_name: {{DEV_NAMESPACE}}_python_latest_web
+        restart: unless-stopped
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - PIP_NO_CACHE_DIR=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # MariaDB - MySQL Compatible Database
+    # ==========================================================================
+    mariadb:
+        image: mariadb:${MARIADB_TAG}
+        container_name: {{DEV_NAMESPACE}}_mariadb
+        restart: unless-stopped
+        environment:
+            - MYSQL_DATABASE=${MYSQL_DATABASE}
+            - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
+            - MYSQL_USER=${MYSQL_USER}
+            - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+            - TZ=Asia/Ho_Chi_Minh
+        ports:
+            - "${MYSQL_EXPOSING_PORT}:3306"
+        volumes:
+            - mariadb-data:/var/lib/mysql
+            # - ./mariadb-init:/docker-entrypoint-initdb.d:ro
+        command: >
+            --character-set-server=utf8mb4
+            --collation-server=utf8mb4_unicode_ci
+            --max_allowed_packet=256M
+            --innodb_buffer_pool_size=512M
+        networks:
+            - {{DEV_NAMESPACE}}
+        healthcheck:
+            test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+            interval: 10s
+            timeout: 5s
+            retries: 5
+
+    # ==========================================================================
+    # Adminer - Lightweight Database Management
+    # ==========================================================================
+    adminer:
+        image: adminer:4.8.1
+        container_name: {{DEV_NAMESPACE}}_adminer
+        restart: unless-stopped
+        volumes:
+            - "./etc/adminer/0-upload_large_dumps.ini:/usr/local/etc/php/conf.d/0-upload_large_dumps.ini:ro"
+        ports:
+            - "${ADMINIER_WEB_EXPOSING_PORT}:8080"
+        environment:
+            - ADMINER_DESIGN=nette
+            - ADMINER_DEFAULT_SERVER=mariadb
+        networks:
+            - {{DEV_NAMESPACE}}
+        depends_on:
+            - mariadb
+
+    # ==========================================================================
+    # PhpMyAdmin - Full Featured Database Management
+    # ==========================================================================
+    phpmyadmin:
+        image: phpmyadmin/phpmyadmin:latest
+        container_name: {{DEV_NAMESPACE}}_phpmyadmin
+        restart: unless-stopped
+        ports:
+            - "${PHPMYADMIN_WEB_EXPOSING_PORT}:80"
+        environment:
+            - PMA_ARBITRARY=1
+            - PMA_HOST=mariadb
+            - PHP_UPLOAD_MAX_FILESIZE=1G
+            - PHP_POST_MAX_SIZE=1G
+            - PHP_MEMORY_LIMIT=512M
+            - PHPMYADMIN_ALLOW_ARBITRARY_SERVER=yes
+            - PHP_MAX_INPUT_VARS=10000
+            - UPLOAD_LIMIT=1G
+        networks:
+            - {{DEV_NAMESPACE}}
+        depends_on:
+            - mariadb
+
+    # ==========================================================================
+    # SSDB - Redis Alternative (SSD Optimized)
+    # ==========================================================================
+    ssdb:
+        image: benyoo/ssdb
+        container_name: {{DEV_NAMESPACE}}_ssdb
+        restart: unless-stopped
+        volumes:
+            - "./etc/ssdb/ssdb.conf:/etc/ssdb.conf:ro"
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    # ==========================================================================
+    # PHP SSDB Admin - SSDB Web Interface
+    # ==========================================================================
+    phpssdbadmin:
+        build:
+            context: "./build/phpssdbadmin"
+        container_name: {{DEV_NAMESPACE}}_phpssdbadmin
+        restart: unless-stopped
+        ports:
+            - "${PHPSSDBADMIN_WEB_EXPOSING_PORT}:80"
+        networks:
+            - {{DEV_NAMESPACE}}
+        depends_on:
+            - ssdb
+
+    # ==========================================================================
+    # Redis - In-Memory Data Store
+    # ==========================================================================
+    redis:
+        image: redis:7-alpine
+        container_name: {{DEV_NAMESPACE}}_redis
+        restart: unless-stopped
+        ports:
+            - "${REDIS_EXPOSING_PORT}:6379"
+        volumes:
+            - "./etc/redis/redis.conf:/usr/local/etc/redis/redis.conf:ro"
+        command: redis-server /usr/local/etc/redis/redis.conf
+        networks:
+            - {{DEV_NAMESPACE}}
+        healthcheck:
+            test: ["CMD", "redis-cli", "ping"]
+            interval: 10s
+            timeout: 3s
+            retries: 5
+
+    # ==========================================================================
+    # PHP Redis Admin - Redis Web Interface
+    # ==========================================================================
+    phpredisadmin:
+        image: erikdubbelboer/phpredisadmin:latest
+        container_name: {{DEV_NAMESPACE}}_phpredisadmin
+        restart: unless-stopped
+        ports:
+            - "${PHPREDISADMIN_WEB_EXPOSING_PORT}:80"
+        environment:
+            - ADMIN_USER=${REDIS_ADMIN_USER}
+            - ADMIN_PASS=${REDIS_ADMIN_PASS}
+            - REDIS_1_HOST=redis
+            - REDIS_1_PORT=6379
+        networks:
+            - {{DEV_NAMESPACE}}
+        depends_on:
+            - redis
+
+    # ==========================================================================
+    # Elasticsearch - Search and Analytics Engine
+    # ==========================================================================
+    elasticsearch:
+        image: docker.elastic.co/elasticsearch/elasticsearch:8.11.0
+        container_name: {{DEV_NAMESPACE}}_elasticsearch
+        restart: unless-stopped
+        environment:
+            - node.name=es-node-1
+            - cluster.name=yivic-dev-cluster
+            - discovery.type=single-node
+            - bootstrap.memory_lock=true
+            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+            - xpack.security.enabled=false
+            - TZ=Asia/Ho_Chi_Minh
+        ulimits:
+            memlock:
+                soft: -1
+                hard: -1
+            nofile:
+                soft: 65536
+                hard: 65536
+        volumes:
+            - es-data:/usr/share/elasticsearch/data
+        ports:
+            - "${ELASTICSEARCH_PORT:-9200}:9200"
+            - "${ELASTICSEARCH_CLUSTER_PORT:-9300}:9300"
+        networks:
+            - {{DEV_NAMESPACE}}
+        healthcheck:
+            test: ["CMD-SHELL", "curl -f http://127.0.0.1:9200/_cluster/health || exit 1"]
+            interval: 30s
+            timeout: 10s
+            retries: 5

--- a/docker-compose.yml.example
+++ b/docker-compose.yml.example
@@ -3,8 +3,11 @@ networks:
     {{DEV_NAMESPACE}}:
         name: {{DEV_NAMESPACE}}_default
 services:
+    # ============================================================================
+    # Nginx Services
+    # ============================================================================
     nginx_main:
-        image: nginx:${NGINX_VERSION}-alpine
+        image: manhphucofficial:nginx:${NGINX_VERSION}-alpine-custom
         container_name: {{DEV_NAMESPACE}}_nginx_main
         volumes:
             - "./shared:/shared"
@@ -16,9 +19,12 @@ services:
             - "${NGINX_HTTP_EXPOSING_PORT}:80"
             - "${NGINX_HTTPS_EXPOSING_PORT}:443"
         environment:
-            NGINX_HOST:
+            NGINX_HOST: ${NGINX_HOST}
         networks:
             - {{DEV_NAMESPACE}}
+    # ============================================================================
+    # PHP Services
+    # ============================================================================
     php72_fpm:
         image: manhphucofficial/php:7.2-fpm
         container_name: {{DEV_NAMESPACE}}_php72_fpm
@@ -37,6 +43,24 @@ services:
     # php72_cli:
     #     image: manhphucofficial/php:7.2-cli
     #     container_name: {{DEV_NAMESPACE}}_php72_cli
+
+    php82_web:
+        image: manhphucofficial/php82_web
+        container_name: ${DEV_NAMESPACE}_php82_web
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "./etc/php82/php-custom.ini:/etc/php/8.2/fpm/conf.d/php-custom.ini"
+            - "./etc/ssl/dev-srv.org.key:/etc/nginx/certs/dev-srv.org.key"
+            - "./etc/ssl/dev-srv.org.bundle.crt:/etc/nginx/certs/dev-srv.org.crt"
+        environment:
+            - PHP_UPLOAD_MAX_FILEZISE=256M
+            - PHP_POST_MAX_SIZE=256M
+            - PHP_MEMORY_LIMIT=128M
+            - PHP_MAX_EXECUTION_TIME=120
+            - PHP_MAX_INPUT_TIME=90
+        networks:
+            - {{DEV_NAMESPACE}}
     php_latest_fpm:
         image: manhphucofficial/php:latest-fpm
         container_name: {{DEV_NAMESPACE}}_php_latest_fpm
@@ -44,6 +68,8 @@ services:
             - "./shared:/shared"
             - "${WWW_DIR}:/var/www/html"
             - "./etc/php-latest/php-custom.ini:/etc/php/7.4/fpm/conf.d/php-custom.ini"
+            - "./etc/ssl/dev-srv.org.key:/etc/nginx/certs/dev-srv.org.key"
+            - "./etc/ssl/dev-srv.org.bundle.crt:/etc/nginx/certs/dev-srv.org.crt"
         environment:
             - PHP_UPLOAD_MAX_FILEZISE=256M
             - PHP_POST_MAX_SIZE=256M
@@ -55,13 +81,84 @@ services:
     # php_latest_cli:
     #     image: manhphucofficial/php:latest-cli
     #     container_name: {{DEV_NAMESPACE}}_php_latest_cli
+    # ============================================================================
+    # Python Services
+    # ============================================================================
+    python310_web:
+        image: manhphucofficial/python:3.10-web
+        container_name: ${DEV_NAMESPACE}_python310_web
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    python311_web:
+        image: manhphucofficial/python:3.11-web
+        container_name: ${DEV_NAMESPACE}_python311_web
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    python312_web:
+        image: manhphucofficial/python:3.12-web
+        container_name: ${DEV_NAMESPACE}_python312_web
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+
+    python_latest_web:
+        image: manhphucofficial/python:latest-web
+        container_name: ${DEV_NAMESPACE}_python_latest_web
+        volumes:
+            - "./shared:/shared"
+            - "${WWW_DIR}:/var/www/html"
+            - "${PYTHON_LOG_DIR}:/var/log/python"
+        environment:
+            - PYTHONUNBUFFERED=1
+            - PYTHONDONTWRITEBYTECODE=1
+            - TZ=Asia/Ho_Chi_Minh
+        working_dir: /var/www/html
+        command: tail -f /dev/null
+        networks:
+            - {{DEV_NAMESPACE}}
+    # ============================================================================
+    # Database Services
+    # ============================================================================
     mariadb:
-        image: mariadb
+        image: mariadb:${MARIADB_TAG}
         environment:
             - MYSQL_DATABASE=${MYSQL_DATABASE}
             - MYSQL_ROOT_PASSWORD=${MYSQL_ROOT_PASSWORD}
             - MYSQL_USER=${MYSQL_USER}
             - MYSQL_PASSWORD=${MYSQL_PASSWORD}
+        ports:
+            - "${MYSQL_EXPOSING_PORT}:3306"
         volumes:
             # - ./mariadb-init:/docker-entrypoint-initdb.d # Place init .sql file(s) here.
             # - /path/to/mariadb/data/on/host:/var/lib/mysql # I want to manage volumes manually.
@@ -70,6 +167,9 @@ services:
               target: /var/lib/mysql
         networks:
             - {{DEV_NAMESPACE}}
+    # ============================================================================
+    # Admin Tools
+    # ============================================================================
     adminer:
         image: adminer:4.7.7
         volumes:

--- a/etc/nginx/default.conf.example
+++ b/etc/nginx/default.conf.example
@@ -1,5 +1,8 @@
 # Nginx configuration
 
+# Docker DNS resolver for lazy resolution
+resolver 127.0.0.11 valid=10s ipv6=off;
+
 #Adjust client timeouts
 client_max_body_size 0;
 client_body_buffer_size 1k;
@@ -30,8 +33,11 @@ map $host $global_local_php_document_root {
   default /Users/<username>/workspace/www;
 }
 
+# ------------------------------------------------------------------------------
+# PHP upstreams
+# ------------------------------------------------------------------------------
 upstream docker_php {
-    server php72_fpm:9000;
+    server php82_web:9000;
 }
 
 upstream local_php56 {
@@ -50,46 +56,36 @@ upstream backend_php {
     server php_latest_fpm:9000;
 }
 
+# ────────────────────────────────────────────────
+# HTTP redirect to HTTPS for *.dev-srv.org
 server {
     listen 80 default_server;
     listen [::]:80 default_server;
-    server_name _;
-
-    index index.php index.html;
-    error_log  /var/log/nginx/error.log;
-    access_log /var/log/nginx/access.log;
-    root /var/www/html;
-    set $php_fpm_document_root $global_php_document_root;
-
-    location / {
-        autoindex on;
-    }
-
-    location ~ \.php$ {
-        try_files $uri =404;
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass backend_php;
-        fastcgi_index index.php;
-        include fastcgi_params;
-        fastcgi_param SCRIPT_FILENAME $php_fpm_document_root$fastcgi_script_name;
-        fastcgi_param PATH_INFO $fastcgi_path_info;
-    }
+    server_name ~^(?<subdomain>.+)\.dev-srv\.org$;
+    return 301 https://$host$request_uri;
 }
 
+# ────────────────────────────────────────────────
+# HTTPS block for wildcard *.dev-srv.org
 server {
-    listen 443 ssl;
-    server_name _;
+    listen 443 ssl default_server;
+    listen [::]:443 ssl default_server;
+    server_name ~^(?<subdomain>.+)\.dev-srv\.org$;
     fastcgi_param HTTPS on;
 
-    ssl_certificate /etc/ssl/ca.pem;
-    ssl_certificate_key /etc/ssl/ca-key.pem;
-    ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+    ssl_certificate     /etc/ssl/dev-srv.org.bundle.crt;
+    ssl_certificate_key /etc/ssl/dev-srv.org.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # Dynamic root/log per subdomain
+    root /var/www/html/$subdomain;
+    set $php_fpm_document_root $global_php_document_root/$subdomain;
 
     index index.php index.html;
-    error_log  /var/log/nginx/error.log;
-    access_log /var/log/nginx/access.log;
-    root /var/www/html;
-    set $php_fpm_document_root $global_php_document_root;
+
+    error_log  /var/log/nginx/$subdomain-error.log;
+    access_log /var/log/nginx/$subdomain-access.log;
 
     add_header X-SCRIPT_FILENAME SCRIPT_FILENAME;
     add_header X-fastcgi_script_name $fastcgi_script_name;
@@ -97,12 +93,13 @@ server {
 
     location / {
         autoindex on;
+        try_files $uri $uri/ =404;
     }
 
     location ~ \.php$ {
         try_files $uri =404;
         fastcgi_split_path_info ^(.+\.php)(/.+)$;
-        fastcgi_pass backend_php;
+        fastcgi_pass docker_php;
         fastcgi_index index.php;
         include fastcgi_params;
         fastcgi_param SCRIPT_FILENAME $php_fpm_document_root$fastcgi_script_name;
@@ -110,4 +107,6 @@ server {
     }
 }
 
+# ────────────────────────────────────────────────
+# Include custom sites if any
 include /etc/nginx/conf.d/sites-enabled/*.conf;

--- a/etc/nginx/python.locations
+++ b/etc/nginx/python.locations
@@ -1,0 +1,126 @@
+# ============================================================================
+# Python Application Proxy Configuration with Lazy DNS Resolution
+# ============================================================================
+# This config uses variables instead of upstream blocks to avoid
+# "host not found" errors when Python containers aren't running yet.
+# DNS is resolved ONLY when the location is actually accessed.
+#
+# USAGE: Set $python_version variable in your site config before including this file
+# Example: set $python_version "python312_web";
+# ============================================================================
+
+# Main application proxy
+location / {
+    # Lazy DNS resolution - only resolve when accessed, not at startup
+    # Uses $python_version variable set in site config
+    set $backend "$python_version:8000";
+    proxy_pass http://$backend;
+
+    proxy_http_version 1.1;
+
+    # Headers for proxying
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header X-Forwarded-Host $host;
+    proxy_set_header X-Forwarded-Port $server_port;
+
+    # WebSocket support (for FastAPI, Django Channels, Socket.io)
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    # Timeouts
+    proxy_connect_timeout 600s;
+    proxy_send_timeout 600s;
+    proxy_read_timeout 600s;
+
+    # Buffering
+    proxy_buffering off;
+    proxy_request_buffering off;
+}
+
+# Static files (FastAPI/Flask/Django static files)
+location /static/ {
+    alias /var/www/html/$subdomain/static/;
+    expires 30d;
+    access_log off;
+    add_header Cache-Control "public, immutable";
+}
+
+# Media files (user uploads)
+location /media/ {
+    alias /var/www/html/$subdomain/media/;
+    expires 7d;
+    access_log off;
+}
+
+# FastAPI/Django admin static files
+location /admin/static/ {
+    alias /var/www/html/$subdomain/static/admin/;
+    expires 30d;
+    access_log off;
+}
+
+# Health check endpoint
+location /health {
+    set $backend "$python_version:8000";
+    proxy_pass http://$backend/health;
+    access_log off;
+}
+
+# API documentation (FastAPI auto-docs)
+location /docs {
+    set $backend "$python_version:8000";
+    proxy_pass http://$backend/docs;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+}
+
+location /redoc {
+    set $backend "$python_version:8000";
+    proxy_pass http://$backend/redoc;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+}
+
+location /openapi.json {
+    set $backend "$python_version:8000";
+    proxy_pass http://$backend/openapi.json;
+    proxy_set_header Host $host;
+}
+
+# Favicon
+location = /favicon.ico {
+    log_not_found off;
+    access_log off;
+    expires max;
+}
+
+# Robots.txt
+location = /robots.txt {
+    allow all;
+    log_not_found off;
+    access_log off;
+}
+
+# Deny access to hidden files
+location ~ /\. {
+    deny all;
+    access_log off;
+    log_not_found off;
+}
+
+# Deny access to Python source files (security)
+location ~* \.(py|pyc|pyo|pyd|pyw|pyz)$ {
+    deny all;
+    access_log off;
+    log_not_found off;
+}
+
+# Deny access to sensitive files
+location ~* (requirements\.txt|Pipfile|\.env|\.git|\.venv|__pycache__|\.pytest_cache)$ {
+    deny all;
+    access_log off;
+    log_not_found off;
+}

--- a/etc/nginx/sites-enabled/python-sample.conf.example
+++ b/etc/nginx/sites-enabled/python-sample.conf.example
@@ -1,0 +1,54 @@
+# ============================================================================
+# Python Application Template
+# ============================================================================
+# File: etc/nginx/sites-enabled/python-site.conf.example
+#
+# Setup:
+# 1. Copy this file: cp python-site.conf.example your-app.conf
+# 2. Replace "your-app" with your actual app name throughout this file
+# 3. Replace "your.domain.com" with your actual domain
+# 4. Create project folder: mkdir -p ../www/your-app
+# 5. Add to /etc/hosts: 127.0.0.1 your.domain.com
+# 6. Choose Python version below (python310_web | python311_web | python312_web)
+# 7. Reload nginx: docker-compose restart nginx_main
+# 8. Start app: ./scripts/python/autostart-python-apps.sh dev
+# ============================================================================
+
+# HTTP -> HTTPS redirect
+server {
+    listen 80;
+    server_name your.domain.com;
+    return 301 https://$host$request_uri;
+}
+
+# HTTPS server
+server {
+    listen 443 ssl;
+    server_name your.domain.com;
+    fastcgi_param HTTPS on;
+
+    # SSL Configuration
+    ssl_certificate     /etc/ssl/dev-srv.org.bundle.crt;
+    ssl_certificate_key /etc/ssl/dev-srv.org.key;
+    ssl_protocols       TLSv1.2 TLSv1.3;
+    ssl_prefer_server_ciphers on;
+
+    # Logging
+    error_log  /var/log/nginx/your.domain.com-error.log;
+    access_log /var/log/nginx/your.domain.com-access.log;
+
+    # Document root (for static files if needed)
+    root /var/www/html/your-app;
+
+    # Set subdomain variable for python.locations
+    set $subdomain your-app;
+
+    # ═══════════════════════════════════════════════════════════════════
+    # PYTHON VERSION - Change this to use different Python version
+    # Options: python310_web | python311_web | python312_web | python_latest_web
+    # ═══════════════════════════════════════════════════════════════════
+    set $python_version "python312_web";
+
+    # Include Python proxy rules
+    include conf.d/python.locations;
+}

--- a/etc/nginx/sites-enabled/sample.conf.example
+++ b/etc/nginx/sites-enabled/sample.conf.example
@@ -18,8 +18,8 @@ server {
     server_name your.domain.com;
     fastcgi_param HTTPS on;
 
-    ssl_certificate /etc/ssl/ca.pem;
-    ssl_certificate_key /etc/ssl/ca-key.pem;
+    ssl_certificate     /etc/ssl/dev-srv.org.bundle.crt;
+    ssl_certificate_key /etc/ssl/dev-srv.org.key;
     ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
 
     index index.php index.html;

--- a/etc/php82/php-custom.ini
+++ b/etc/php82/php-custom.ini
@@ -1,0 +1,19 @@
+; Show PHP errors
+display_errors = on
+
+; Use PHP short tags
+short_open_tag = off
+
+openssl.cafile=/usr/local/share/ca.pem
+
+upload_max_filesize = ${PHP_UPLOAD_MAX_FILEZISE}
+post_max_size = ${PHP_POST_MAX_SIZE}
+
+memory_limit = ${PHP_MEMORY_LIMIT}
+max_execution_time = ${PHP_MAX_EXECUTION_TIME}
+max_input_time = ${PHP_MAX_INPUT_TIME}
+
+# opcache
+opcache.enable = on
+opcache.enable_cli = off
+opcache.revalidate_freq = 2

--- a/scripts/python/autostart-python-apps.sh
+++ b/scripts/python/autostart-python-apps.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+# ==============================================================================
+# Auto-start All Python Apps (with Dev/Prod Mode)
+# File: scripts/python/autostart-python-apps.sh
+# ==============================================================================
+# Usage:
+#   ./scripts/python/autostart-python-apps.sh         # Production mode
+#   ./scripts/python/autostart-python-apps.sh dev     # Development mode (auto-reload)
+# ==============================================================================
+
+set -e
+
+# Check mode
+MODE=${1:-prod}
+WWW_DIR="/var/www/html"
+LOG_DIR="/var/log/python"
+
+# Colors
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+RED='\033[0;31m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+if [ "$MODE" == "dev" ]; then
+    echo -e "${CYAN}╔════════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║${NC}  ${YELLOW}Auto-starting Python Apps (DEV MODE)${NC}                      ${CYAN}║${NC}"
+    echo -e "${CYAN}║${NC}  ${GREEN}Auto-reload enabled - Code changes reload automatically${NC}  ${CYAN}║${NC}"
+    echo -e "${CYAN}╚════════════════════════════════════════════════════════════════╝${NC}"
+else
+    echo -e "${BLUE}╔════════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${BLUE}║${NC}  ${GREEN}Auto-starting Python Apps (PRODUCTION MODE)${NC}               ${BLUE}║${NC}"
+    echo -e "${BLUE}╚════════════════════════════════════════════════════════════════╝${NC}"
+fi
+echo ""
+
+# Function to detect Python version from nginx config
+detect_python_version() {
+    local app_name=$1
+    local config_file="etc/nginx/sites-enabled/${app_name}.conf"
+
+    if [ -f "$config_file" ]; then
+        # Extract $python_version from nginx config
+        local version=$(grep 'set $python_version' "$config_file" | sed 's/.*"\(.*\)".*/\1/')
+        if [ -n "$version" ]; then
+            echo "$version"
+        else
+            # Default to python311_web if not found
+            echo "python311_web"
+        fi
+    else
+        # Default to python311_web if config not found
+        echo "python311_web"
+    fi
+}
+
+# Get all Python containers
+PYTHON_CONTAINERS=$(docker ps --filter "name=yivic_dev_suite_python" --format "{{.Names}}")
+
+if [ -z "$PYTHON_CONTAINERS" ]; then
+    echo -e "${RED}❌ No Python containers are running!${NC}"
+    echo -e "${YELLOW}Start them with: docker-compose up -d${NC}"
+    exit 1
+fi
+
+echo -e "${BLUE}🐍 Available Python containers:${NC}"
+for container in $PYTHON_CONTAINERS; do
+    echo -e "   ${GREEN}✓${NC} $container"
+done
+echo ""
+
+# Stop all existing Python processes in all containers
+echo -e "${BLUE}🛑 Stopping existing Python apps in all containers...${NC}"
+for container in $PYTHON_CONTAINERS; do
+    docker exec $container pkill -f "uvicorn|gunicorn" 2>/dev/null || true
+done
+sleep 1
+
+# Get list of Python apps
+APPS=$(ls -d ../www/*/ 2>/dev/null | xargs -n 1 basename 2>/dev/null || echo "")
+
+if [ -z "$APPS" ]; then
+    echo -e "${YELLOW}⚠️  No Python apps found in ../www/${NC}"
+    exit 0
+fi
+
+STARTED_COUNT=0
+
+# Start each app
+for app_name in $APPS; do
+    # Skip special directories
+    if [[ "$app_name" == "build_dockerfile" ]]; then
+        continue
+    fi
+
+    # Check if has .py files
+    if ! ls ../www/$app_name/*.py >/dev/null 2>&1; then
+        continue
+    fi
+
+    echo -e "${BLUE}📦 Found: $app_name${NC}"
+
+    # Detect Python version from nginx config
+    CONTAINER_NAME=$(detect_python_version "$app_name")
+    CONTAINER="yivic_dev_suite_${CONTAINER_NAME}"
+
+    echo -e "${BLUE}   🐍 Python version: ${GREEN}${CONTAINER_NAME}${NC}"
+
+    # Check if container exists and is running
+    if ! docker ps | grep -q "$CONTAINER"; then
+        echo -e "${RED}   ❌ Container $CONTAINER is not running!${NC}"
+        echo -e "${YELLOW}   ⏭️  Skipping...${NC}"
+        echo ""
+        continue
+    fi
+
+    # Detect app type
+    APP_TYPE=$(docker exec $CONTAINER bash -c "
+        cd /var/www/html/$app_name
+        if [ -f 'main.py' ] && grep -q 'FastAPI\|fastapi' main.py 2>/dev/null; then
+            echo 'fastapi-main'
+        elif [ -f 'app.py' ] && grep -q 'FastAPI\|fastapi' app.py 2>/dev/null; then
+            echo 'fastapi-app'
+        elif [ -f 'app.py' ] && grep -q 'Flask\|flask' app.py 2>/dev/null; then
+            echo 'flask'
+        elif [ -f 'manage.py' ]; then
+            echo 'django'
+        else
+            echo 'unknown'
+        fi
+    ")
+
+    # Dev mode: Add --reload flag
+    if [ "$MODE" == "dev" ]; then
+        RELOAD_FLAG="--reload"
+        RELOAD_TEXT="${YELLOW}(auto-reload)${NC}"
+    else
+        RELOAD_FLAG=""
+        RELOAD_TEXT=""
+    fi
+
+    case $APP_TYPE in
+        fastapi-main)
+            echo -e "${GREEN}   ▶️  Starting FastAPI app: uvicorn main:app $RELOAD_TEXT${NC}"
+            docker exec -d $CONTAINER bash -c "cd /var/www/html/$app_name && nohup uvicorn main:app --host 0.0.0.0 --port 8000 $RELOAD_FLAG > /var/log/python/$app_name.log 2>&1 &"
+            STARTED_COUNT=$((STARTED_COUNT + 1))
+            ;;
+        fastapi-app)
+            echo -e "${GREEN}   ▶️  Starting FastAPI app: uvicorn app:app $RELOAD_TEXT${NC}"
+            docker exec -d $CONTAINER bash -c "cd /var/www/html/$app_name && nohup uvicorn app:app --host 0.0.0.0 --port 8000 $RELOAD_FLAG > /var/log/python/$app_name.log 2>&1 &"
+            STARTED_COUNT=$((STARTED_COUNT + 1))
+            ;;
+        flask)
+            echo -e "${GREEN}   ▶️  Starting Flask app: gunicorn app:app $RELOAD_TEXT${NC}"
+            if [ "$MODE" == "dev" ]; then
+                # Flask dev mode with auto-reload
+                docker exec -d $CONTAINER bash -c "cd /var/www/html/$app_name && nohup flask run --host 0.0.0.0 --port 8000 --reload > /var/log/python/$app_name.log 2>&1 &"
+            else
+                docker exec -d $CONTAINER bash -c "cd /var/www/html/$app_name && nohup gunicorn -w 4 -b 0.0.0.0:8000 app:app > /var/log/python/$app_name.log 2>&1 &"
+            fi
+            STARTED_COUNT=$((STARTED_COUNT + 1))
+            ;;
+        django)
+            echo -e "${GREEN}   ▶️  Starting Django app $RELOAD_TEXT${NC}"
+            if [ "$MODE" == "dev" ]; then
+                # Django dev server with auto-reload
+                docker exec -d $CONTAINER bash -c "cd /var/www/html/$app_name && nohup python manage.py runserver 0.0.0.0:8000 > /var/log/python/$app_name.log 2>&1 &"
+            else
+                docker exec -d $CONTAINER bash -c "cd /var/www/html/$app_name && nohup gunicorn \$(ls -d */ | head -1 | sed 's/\///').wsgi:application -w 4 -b 0.0.0.0:8000 > /var/log/python/$app_name.log 2>&1 &"
+            fi
+            STARTED_COUNT=$((STARTED_COUNT + 1))
+            ;;
+        *)
+            echo -e "${YELLOW}   ⏭️  Skipped (not a recognized Python web app)${NC}"
+            ;;
+    esac
+
+    echo ""
+done
+
+echo -e "${GREEN}✅ Started $STARTED_COUNT Python app(s)${NC}"
+
+# Reload nginx to update IPs
+echo ""
+echo -e "${BLUE}🔄 Reloading nginx...${NC}"
+docker-compose restart nginx_main >/dev/null 2>&1
+sleep 2
+
+echo ""
+echo -e "${GREEN}✅ Done!${NC}"
+
+if [ "$MODE" == "dev" ]; then
+    echo ""
+    echo -e "${CYAN}╔════════════════════════════════════════════════════════════════╗${NC}"
+    echo -e "${CYAN}║${NC}  ${YELLOW}DEV MODE ACTIVE${NC}                                            ${CYAN}║${NC}"
+    echo -e "${CYAN}║${NC}  Apps will auto-reload when you edit Python files          ${CYAN}║${NC}"
+    echo -e "${CYAN}║${NC}  No need to restart when changing code!                    ${CYAN}║${NC}"
+    echo -e "${CYAN}╚════════════════════════════════════════════════════════════════╝${NC}"
+fi
+
+echo ""
+echo -e "${BLUE}📊 Check running processes in all containers:${NC}"
+for container in $PYTHON_CONTAINERS; do
+    PROCESSES=$(docker exec $container ps aux | grep -E "uvicorn|gunicorn|flask|manage.py" | grep -v grep || echo "")
+    if [ -n "$PROCESSES" ]; then
+        echo -e "${GREEN}▶ $container:${NC}"
+        echo "$PROCESSES"
+    fi
+done
+
+echo ""
+echo -e "${BLUE}📜 View logs:${NC}"
+echo -e "   docker exec <container> tail -f /var/log/python/<app-name>.log"
+
+if [ "$MODE" == "dev" ]; then
+    echo ""
+    echo -e "${YELLOW}💡 Tip: When ready for production, run:${NC}"
+    echo -e "   ${GREEN}./scripts/python/autostart-python-apps.sh${NC}"
+fi


### PR DESCRIPTION
## Summary
Add comprehensive Python development environment to the dev suite, enabling Python 3.10, 3.11, 3.12, and latest versions alongside the existing PHP stack.

## Changes

### Docker Services
- Add Python 3.10-web container
- Add Python 3.11-web container  
- Add Python 3.12-web container
- Add Python latest-web container
- Configure Python-specific environment variables
- Add Python logging directory support

### Nginx Configuration
- Add Python location blocks (`etc/nginx/python.locations`)
- Create Python sample site config
- Update default Nginx configuration for Python support

### Environment & Configuration
- Add `PYTHON_LOG_DIR` for Python application logs
- Add `PYTHON_DEFAULT_VERSION` variable (default: 3.11)
- Add optional Python port configurations (commented)
- Add docker-compose override example

### PHP 8.2 Support
- Add PHP 8.2 configuration files

### Scripts & Utilities
- Add Python utility scripts directory (`scripts/python/`)

## Docker Images
All images available on Docker Hub:
- `manhphucofficial/python:3.10-web`
- `manhphucofficial/python:3.11-web`
- `manhphucofficial/python:3.12-web`
- `manhphucofficial/python:latest-web`

## Testing
- [x] All containers start successfully
- [x] Python services run without errors
- [x] Nginx configuration validated
- [x] No conflicts with existing PHP services
- [x] Environment variables working correctly

## Type
- [x] Feature
- [ ] Bug fix
- [ ] Documentation

## Breaking Changes
None. This is a pure addition to the existing stack.